### PR TITLE
fix: select new token & chain when it's diff from prev value.

### DIFF
--- a/src/pages/pools/components/AddLiquidity/index.tsx
+++ b/src/pages/pools/components/AddLiquidity/index.tsx
@@ -465,24 +465,30 @@ function AddLiquidity() {
   }
 
   function handleTokenChange(selectedToken: Option) {
-    const { symbol: tokenSymbol } = tokens.find(
+    const { symbol: newTokenSymbol } = tokens.find(
       tokenObj => tokenObj.symbol === selectedToken.id,
     )!;
-    queryClient.removeQueries();
-    reset();
-    navigate(`/pools/add-liquidity/${chainId}/${tokenSymbol}`);
+
+    if (newTokenSymbol !== tokenSymbol) {
+      queryClient.removeQueries();
+      reset();
+      navigate(`/pools/add-liquidity/${chainId}/${newTokenSymbol}`);
+    }
   }
 
   function handleChainChange(selectedChain: Option) {
-    const { chainId } = chains.find(
+    const { chainId: newChainId } = chains.find(
       chainObj => chainObj.chainId === selectedChain.id,
     )!;
-    const [{ symbol: tokenSymbol }] = tokens.filter(
-      tokenObj => tokenObj[chainId] && tokenObj[chainId].isSupported,
+    const [{ symbol: newTokenSymbol }] = tokens.filter(
+      tokenObj => tokenObj[newChainId] && tokenObj[newChainId].isSupported,
     );
-    queryClient.removeQueries();
-    reset();
-    navigate(`/pools/add-liquidity/${chainId}/${tokenSymbol}`);
+
+    if (chainId && newChainId !== Number.parseInt(chainId, 10)) {
+      queryClient.removeQueries();
+      reset();
+      navigate(`/pools/add-liquidity/${newChainId}/${newTokenSymbol}`);
+    }
   }
 
   function handleNetworkChange() {
@@ -662,7 +668,6 @@ function AddLiquidity() {
                 selected={selectedToken}
                 setSelected={tokenOption => {
                   handleTokenChange(tokenOption);
-                  reset();
                 }}
                 label={'asset'}
               />
@@ -671,7 +676,6 @@ function AddLiquidity() {
                 selected={selectedChain}
                 setSelected={chainOption => {
                   handleChainChange(chainOption);
-                  reset();
                 }}
                 label={'network'}
               />


### PR DESCRIPTION
**Description:**

Selecting the same token or chain is not loading the pool states.

**Reproduction:**

1. Go to add liquidity screen and select a token chain pair. For example USDC on Polygon.
2. Select USDC again and the state would not load properly.

https://user-images.githubusercontent.com/17976252/160225613-31a3eba6-0382-414f-bf04-e720b004e7f8.mov
