### PR TITLE
feat: network filtering based on flags.

### DIFF
--- a/src/hooks/useNetworks.ts
+++ b/src/hooks/useNetworks.ts
@@ -2,6 +2,8 @@ import { config } from 'config';
 import { useQuery } from 'react-query';
 
 export type Network = {
+  bridgeOpen: boolean;
+  poolsOpen: boolean;
   enabled: boolean;
   nativeToken: string;
   nativeDecimal: number;
@@ -55,7 +57,16 @@ const networksEndpoint = `${config.hyphen.baseURL}/api/v1/configuration/networks
 function fetchNetworks(): Promise<Network[]> {
   return fetch(networksEndpoint)
     .then(res => res.json())
-    .then(data => data.message.filter((network: Network) => network.enabled));
+    .then(data =>
+      data.message.filter(
+        // Filter out networks which are not enabled and
+        // have neither of bridgeOpen or poolsOpen booleans set to true.
+        // When both bridgeOpen & poolsOpen booleans are false
+        // the network is hidden across the whole app.
+        (network: Network) =>
+          network.enabled && (network.bridgeOpen || network.poolsOpen),
+      ),
+    );
 }
 
 function useNetworks() {

--- a/src/pages/bridge/components/NetworkSelectors.tsx
+++ b/src/pages/bridge/components/NetworkSelectors.tsx
@@ -21,22 +21,31 @@ const NetworkSelectors: React.FC<INetworkSelectorsProps> = () => {
 
   const fromChainOptions = useMemo(
     () =>
-      networks?.map(network => ({
-        id: network.chainId,
-        name: network.name,
-        image: network.image,
-      })),
+      networks
+        // filter out networks which are disabled for bridge.
+        ?.filter(network => network.bridgeOpen)
+        .map(network => ({
+          id: network.chainId,
+          name: network.name,
+          image: network.image,
+        })),
     [networks],
   );
 
   const toChainOptions = useMemo(() => {
-    return networks
-      ?.filter(network => network.chainId !== fromChain?.chainId)
-      .map(network => ({
-        id: network.chainId,
-        name: network.name,
-        image: network.image,
-      }));
+    return (
+      networks
+        // filter out networks which are disabled for bridge.
+        ?.filter(
+          network =>
+            network.bridgeOpen && network.chainId !== fromChain?.chainId,
+        )
+        .map(network => ({
+          id: network.chainId,
+          name: network.name,
+          image: network.image,
+        }))
+    );
   }, [fromChain?.chainId, networks]);
 
   const selectedFromChain = useMemo(() => {


### PR DESCRIPTION
**Note:**

For this to work the API `https://hyphen-v2-api.biconomy.io/api/v1/configuration/networks` should have `bridgeOpen` and `poolsOpen` flags. They are already on `integration` and `staging`.

These booleans mean the following:

1. If both `bridgeOpen` and `poolsOpen` are false, it means that the network is disabled across the whole app.
2. If `bridgeOpen` is false and `poolsOpen` is true, it means that the network is disabled on bridge but enabled on pools and farms.